### PR TITLE
Docs: Revise README and governance pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,33 @@
-# Talos
+# Welcome to Talos
 
-## General Introduction
+Talos is a decentralized finance (DeFi) protocol that uses AI to manage its treasury and gives the community control over its direction. Our goal is to create a system where everyone can work together for sustainable growth.
 
-Talos is a pioneering protocol in decentralized finance (DeFi) that seamlessly blends advanced AI-driven treasury management with community-focused governance. Designed for a new era of financial innovation, Talos empowers users to participate in a dynamic ecosystem where collective action drives sustainable growth.
+## What Makes Talos Different?
 
-### Core Elements
+### AI-Powered Treasury
 
-#### AI-Managed Treasury
+Talos uses advanced AI to manage a portfolio of assets that generate yield. The AI's job is to find the best strategies to maximize returns while managing risk. To keep this process secure, we use a Trusted Execution Environment (TEE), which is a secure and isolated space for our AI to run. This means:
 
-Leveraging cutting-edge analytics, Talos actively manages a diversified portfolio of yield-bearing assets. By deploying dynamic strategies, the protocol ensures maximum returns while effectively mitigating risk. The integration of Trusted Execution Environment (TEE) based execution enhances this process by providing a secure and isolated environment for critical computations. This TEE integration allows for:
+*   **Secure by Design:** The AI and its data are protected from outside attacks.
+*   **Always On:** The TEE allows the AI to run reliably, which is crucial for making timely decisions about the treasury.
+*   **Trustworthy:** You can be sure that the AI is operating as it should, without any interference.
 
-* **Secure Data Processing:** Sensitive data and AI models are processed in a secure enclave, reducing the risk of manipulation or external attacks.
-* **Protocol Autonomy:** TEE-based execution ensures that the AI agent operates with high reliability and low latency, essential for timely treasury rebalancing and strategy execution.
-* **Trustless Operations:** Users can trust that the underlying computations are executed as programmed, with minimal risk of tampering or external interference.
+### Community-Led Governance
 
-#### Decentralized Governance
+We believe that the community should be in charge. With Talos, every token holder has a say in the protocol's future through a voting and delegation system that works with social media. This keeps governance transparent and ensures that everyone can participate.
 
-Talos distributes decision-making power across its community. Through integrated social media-based voting and a delegation system, every token holder has a direct role in shaping the protocol's future. This decentralized approach ensures that governance remains transparent, participatory, and adaptive to evolving market conditions.
+### Yield-Driven Tokenomics
 
-#### Yield-Focused Tokenomics
+The Talos token is backed by a portfolio of assets that generate real income. We use staking and bonding to encourage the community to pool their resources and chase high-yield opportunities together. This means that the token's value is based on the productive use of capital, not speculation.
 
-At the heart of Talos is a native token backed by a robust portfolio of income-generating assets. Through innovative mechanisms such as bonding and staking, the protocol creates powerful incentives for the community to concentrate their capital into high-yield opportunities. The yield-focused design ensures that returns are driven by real, productive use of capital rather than speculative emissions.
+### The Stag Hunt: A Game of Cooperation
 
-#### Stag Hunt Dynamics
+Talos uses a "stag hunt" model to encourage cooperation. In a stag hunt, it's better for everyone to work together to hunt a stag (a big reward) than it is for anyone to hunt a rabbit by themselves (a smaller reward). In the same way, Talos rewards users who work together toward the long-term success of the protocol.
 
-Talos employs a stag hunt model to encourage deep, coordinated participation. By setting a higher cooperative reward outcome (10,10) versus a lower, non-cooperative baseline (3,3), the protocol aligns individual contributions with the collective goal of unlocking superior long-term rewards. This game-theoretic approach incentivizes participants to commit fully to the protocol’s vision, maximizing yield and enhancing overall treasury performance.
+### Focused on the Arbitrum Ecosystem
 
-#### Focus on the Arbitrum Ecosystem
+We're currently focused on finding yield-bearing opportunities in the Arbitrum ecosystem. Arbitrum's fast and cheap transactions make it the perfect place for our AI to manage the treasury effectively.
 
-Talos will concentrate its efforts on yield-bearing opportunities within the Arbitrum ecosystem. By tapping into Arbitrum’s scalable infrastructure and diverse DeFi landscape, Talos is well-positioned to leverage innovative yield strategies and provide enhanced value to its participants. The efficiency and low fees on Arbitrum create an ideal environment for dynamic, AI-driven treasury management.
+## Our Vision
 
-### The Talos Vision
-
-Talos is more than just a protocol—it is an evolving ecosystem where AI innovation meets decentralized collaboration. By aligning individual incentives with the collective good, Talos sets a new standard for secure, adaptive, and community-driven financial systems. With TEE-based execution ensuring robust protocol autonomy, Talos offers a pathway to meaningful, long-term engagement and growth, particularly within the dynamic environment of Arbitrum.
+Talos is more than just a protocol—it's a community where AI and people work together. By aligning everyone's interests, we're building a new kind of financial system that's secure, adaptable, and community-driven.

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,61 +1,45 @@
-# Governance
+# How Governance Works in Talos
 
-Talos utilizes an upgradeable governance framework that leverages social media for transparent, public decision-making. This system ensures that token stakers actively support their chosen delegates—referred to as governance stewards—who manage proposals and facilitate voting.
+Talos is governed by its community. We use a system that combines token staking with social media to make sure that everyone has a voice and that decisions are made in the open.
 
-### Key Components
+## The Basics
 
-#### 1. Token Staking and Delegation
+### 1. Staking and Delegation
 
-* **Staking Requirement:**\
-  Users stake tokens to gain voting power and commit to the governance process. This mechanism ensures that participants have a vested interest in the protocol's success.
-* **Delegates’ Role:**\
-  Delegates register their social media handles (initially on X/Twitter) to be publicly accountable, representing community sentiment and overseeing governance proposals.
-* **Delegation Incentives:**\
-  Active delegation is rewarded with enhanced voting power or additional token benefits, whereas non-delegators receive reduced rewards. This incentivizes responsible participation and active engagement.
-* **Equal Influence:**\
-  Every delegate wields equal influence, irrespective of the stake size, ensuring that governance remains balanced and community-focused.
+*   **Stake Your Tokens:** To vote, you need to stake your tokens. This shows that you have a vested interest in the future of the protocol.
+*   **Choose a Delegate:** You can delegate your vote to a "governance steward" who will vote on your behalf. These are community members who have registered their social media handles (starting with X/Twitter) to be publicly accountable.
+*   **Incentives for Delegating:** You'll get more rewards if you delegate your vote. If you don't delegate, you'll get fewer rewards. This encourages everyone to participate.
+*   **Everyone is Equal:** Every delegate has the same amount of power, no matter how many tokens they have staked. This keeps things fair and community-focused.
 
-#### 2. Social Media Integration for Voting
+### 2. Voting on Social Media
 
-* **Voting via Social Media:**\
-  Voting is conducted through social media polls on X/Twitter, with only registered delegates eligible to vote. This approach ties governance decisions to verifiable, public identities.
-* **Regular Steward Renewal:**\
-  A monthly voting process is implemented to ensure that delegates remain active and accountable. This regular renewal maintains the integrity and responsiveness of the governance system.
-* **Proposal Submission:**\
-  Anyone can submit proposals for consideration by the delgates
+*   **Public Voting:** All voting happens on X/Twitter polls, and only registered delegates can vote. This makes the whole process transparent and public.
+*   **Keeping Delegates Active:** We hold a vote every month to make sure that our delegates are still active and accountable.
+*   **Anyone Can Make a Proposal:** Anyone can submit a proposal for the delegates to consider.
 
-#### 3. Participation and Accountability Mechanisms
+### 3. Accountability
 
-* **Mandatory Voting:**\
-  Delegates are required to participate in every governance vote. Non-participation incurs penalties, enforcing a consistent level of engagement.
-* **Delegate Reassignment:**\
-  Inactive delegates can be replaced, ensuring that the pool of governance stewards remains dynamic and responsive to the community’s needs.
+*   **Voting is Mandatory:** Delegates have to vote on every proposal. If they don't, they'll be penalized.
+*   **Replacing Inactive Delegates:** If a delegate is inactive, they can be replaced. This keeps our governance system healthy and responsive.
 
-### Process Flow
+## The Process
 
-#### Onboarding and Staking
+### Getting Started
 
-* **Token Staking:**\
-  Users stake tokens to gain governance rights and select a delegate. The system of benefits and penalties encourages responsible delegation and active participation.
+*   **Stake Your Tokens:** Stake your tokens to get the right to vote and choose a delegate.
 
-#### Proposal Lifecycle
+### How a Proposal Becomes a Reality
 
-* **Submission:**\
-  Proposals are submitted with a nominal token deposit, ensuring that only serious ideas are considered.
-* **Community Screening:**\
-  Submitted proposals are screened by the community before being posted as social media polls.
-* **Voting:**\
-  Registered delegates participate in the voting process via X/Twitter polls, ensuring that decisions are made transparently and publicly.
+*   **Submission:** To submit a proposal, you need to make a small token deposit. This is to make sure that only serious proposals are considered.
+*   **Community Review:** The community will review all proposals before they are put to a vote.
+*   **The Vote:** The registered delegates will vote on the proposal using an X/Twitter poll.
 
-#### Post-Vote Enforcement
+### After the Vote
 
-* **Results Aggregation:**\
-  Voting outcomes are aggregated and published, offering clear insights into the community’s preferences.
-* **Reward Distribution:**\
-  Rewards are distributed to active participants, and penalties are imposed on non-participants to maintain high levels of accountability.
-* **Ongoing Steward Votes:**\
-  Monthly steward votes help maintain an active and accountable delegate pool, ensuring that governance remains effective and adaptive.
+*   **See the Results:** The results of the vote will be published for everyone to see.
+*   **Rewards and Penalties:** Rewards will be given to those who participated, and penalties will be given to those who didn't.
+*   **Monthly Delegate Votes:** We hold a vote every month to keep our pool of delegates active and accountable.
 
-### Conclusion
+## Our Goal
 
-Talos's upgradeable governance framework integrates token staking, social media-based voting, and robust accountability mechanisms to ensure transparent, responsible, and community-driven decision-making. This system aligns the interests of all participants, fostering a resilient and dynamic governance structure.
+We've designed our governance system to be transparent, responsible, and community-driven. By aligning everyone's interests, we can build a resilient and dynamic system that can adapt to whatever comes our way.


### PR DESCRIPTION
The previous documentation was criticized for being "LLM slop". This commit is the first step in a series of revisions to make the documentation more readable and less jargony.

I have revised the following files:

- `README.md`: Rewrote the introduction and core elements sections to be more direct and engaging.
- `governance/README.md`: Simplified the language and focused on making the governance process easy to understand for a non-technical audience.

The goal of these changes is to make the documentation more accessible to a wider audience, while still maintaining a professional tone.